### PR TITLE
Add Navigation in Module and minor content fix

### DIFF
--- a/src/core/components/ModuleCard.tsx
+++ b/src/core/components/ModuleCard.tsx
@@ -1,6 +1,6 @@
 import { ChevronDoubleRightIcon } from "@heroicons/react/24/solid";
 import { FC } from "react";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 
 type ModuleCardProps = {
   index: number;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import ReactDOM from "react-dom/client";
 import "./index.scss";
-// import reportWebVitals from "./reportWebVitals";
-import { BrowserRouter, Route, Routes } from "react-router";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import init, { initConsolePanicHook } from "kaspa-wasm";
 import { ModuleLayout } from "./modules/ModuleLayout";
@@ -22,15 +21,15 @@ const setup = async () => {
   root.render(
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<App />}></Route>
+        <Route path="/" element={<App />} />
         <Route path="/modules" element={<ModuleLayout />}>
           {modules.map((m) => (
             <Route
-              key={m.path}
-              path={m.path}
-              element={<Lazy component={m.component}></Lazy>}
-            ></Route>
-          ))}
+            key={m.path}
+            path={m.path}
+            element={<Lazy key={m.path} component={m.component} />}
+          />
+                ))}
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/modules/5-blockdag/ModuleBlockDag.tsx
+++ b/src/modules/5-blockdag/ModuleBlockDag.tsx
@@ -99,12 +99,12 @@ export const ModuleBlockDag: FC = () => {
           <ol>
             <li>
               <strong>Start at the Future:</strong>Look at all current leafs and
-              pick the one with the largest blue block history. This is your
+              pick the one with the highest amount of blue work. This is your
               first selected parent.
             </li>
             <li>
               <strong>Jump to the Past:</strong>Move to this block and examine
-              its parents. Again, choose the one with the biggest blue history.
+              its parents. Again, choose the one with the highest amount of blue work.
             </li>
             <li>
               <strong>Repeat:</strong>Keep doing this, and voilà! You've created
@@ -123,7 +123,7 @@ export const ModuleBlockDag: FC = () => {
 
           <h3>Reorganizations (Reorgs)</h3>
           <p>
-            When the path changes between two Virtual Chain calculations, it's
+            Near the tip of the DAG, when the path changes between two Virtual Chain calculations, it's
             called a reorganization. This is why we wait for confirmations to
             trust a transaction. The more confirmations, the more confident we
             are.

--- a/src/modules/ModuleLayout.tsx
+++ b/src/modules/ModuleLayout.tsx
@@ -1,5 +1,6 @@
-import { ArrowLongLeftIcon } from "@heroicons/react/24/solid";
+import { ArrowLongLeftIcon, ArrowLongRightIcon } from "@heroicons/react/24/solid";
 import { FC, useMemo } from "react";
+import { modules } from "./module";
 import {
   Link,
   Outlet,
@@ -19,16 +20,66 @@ export const ModuleLayout: FC = () => {
       ?.replaceAll("-", " ");
   }, [location]);
 
+  const currentIndex = modules.findIndex((module) =>
+    location.pathname.endsWith(module.path)
+  );
+
+  const handleNavigate = (direction: "prev" | "next") => {
+    const targetIndex = direction === "prev" ? currentIndex - 1 : currentIndex + 1;
+    if (targetIndex >= 0 && targetIndex < modules.length) {
+      navigate(`/modules/${modules[targetIndex].path}`);
+    }
+  };
+
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex < modules.length - 1;
+
+  const nextTitle = hasNext ? modules[currentIndex + 1].title : null;
+  const prevTitle = hasPrev ? modules[currentIndex - 1].title : null;
+
   return (
     <div className="w-100 h-screen select-none relative">
       <Link className="no-underline" to="/">
-        <ArrowLongLeftIcon className="text-white size-12 md:size-16 absolute top-0 md:top-2  left-6 md:left-52 hover:text-secondary hover:cursor-pointer transition-colors" />
+        <ArrowLongLeftIcon className="text-white size-12 md:size-16 absolute top-0 md:top-2 left-6 md:left-52 hover:text-secondary hover:cursor-pointer transition-colors" />
       </Link>
+
       <h3 className="font-rubik inline absolute top-2 md:top-6 text-xl left-24 md:left-72">
         {moduleName ?? ""}
       </h3>
-      <div className="pt-12 py-16 md:pt-20 w-100 border-t border-white">
+
+      <div className="pt-12 py-16 md:pt-20 w-full border-t border-white">
         <Outlet />
+
+        <div className="mt-16 max-w-2xl mx-auto px-4 flex justify-between items-center">
+
+          {/* Previous */}
+          {hasPrev ? (
+            <div className="flex flex-col items-start">
+              <button
+                onClick={() => handleNavigate("prev")}
+                className="flex items-center px-4 py-2 border border-white rounded-md hover:shadow-secondary hover:shadow-sm transition-shadow"
+              >
+                <ArrowLongLeftIcon className="size-5 mr-2" />
+                Previous
+              </button>
+              <span className="text-sm mt-2 text-white/60">{prevTitle}</span>
+            </div>
+          ) : <div />}
+
+          {/* Next */}
+          {hasNext && (
+            <div className="flex flex-col items-end">
+              <button
+                onClick={() => handleNavigate("next")}
+                className="flex items-center px-4 py-2 border border-white rounded-md hover:shadow-secondary hover:shadow-sm transition-shadow"
+              >
+                Next
+                <ArrowLongRightIcon className="size-5 ml-2" />
+              </button>
+              <span className="text-sm mt-2 text-white/60">{nextTitle}</span>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/modules/ModuleLayout.tsx
+++ b/src/modules/ModuleLayout.tsx
@@ -20,8 +20,8 @@ export const ModuleLayout: FC = () => {
       ?.replaceAll("-", " ");
   }, [location]);
 
-  const currentIndex = modules.findIndex((module) =>
-    location.pathname.endsWith(module.path)
+  const currentIndex = modules.findIndex(
+    (module) => `/modules/${module.path}` === location.pathname
   );
 
   const handleNavigate = (direction: "prev" | "next") => {

--- a/src/modules/ModuleLayout.tsx
+++ b/src/modules/ModuleLayout.tsx
@@ -3,14 +3,13 @@ import { FC, useMemo } from "react";
 import {
   Link,
   Outlet,
-  parsePath,
+  useNavigate,
   useLocation,
-  useParams,
-  useRoutes,
-} from "react-router";
+} from "react-router-dom";
 
 export const ModuleLayout: FC = () => {
   const location = useLocation();
+  const navigate = useNavigate();
 
   const moduleName = useMemo(() => {
     return location.pathname


### PR DESCRIPTION
## Why this PR?
I think this is a cool project. The overall flow and modular structure are great and make it really enjoyable to move through. I originally stumbled on a small detail—just a minor incorrectness re [bluescore and bluework](https://github.com/kaspanet/kaspad/pull/1172)—which prompted this PR.

But then I wanted to add something else (navigation!)

## What’s changed?
ModuleBlockDag: Changing BlueScore to BlueWork. Then another line about reorgs near the front of the Dag.

**Navigation Improvements:**

- Replaced `react-router` with `react-router-dom`.
- Introduced forward and back navigation buttons at the end of each module. These make it easier to move through the project in a guided, sequential way.

**Video on Navigation**:
https://github.com/user-attachments/assets/7955e7f3-23d1-4c6e-aacb-df33f3870906

